### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in BlogTwitterCard

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-02 - [XSS in Meta Tags]
+**Vulnerability:** XSS (Cross-Site Scripting) via unsanitized strings in `BlogTwitterCard`.
+**Learning:** The application was manually building HTML strings using `fmt.Sprintf` and `gutils.Dedent` for a GraphQL resolver, which bypassed standard JSON/GraphQL safety and allowed attribute breakout when injecting database or user-supplied strings.
+**Prevention:** Always use `html.EscapeString` (or a proper HTML template engine) when building HTML snippets from dynamic data in Go.

--- a/internal/web/blog/controller/blog.go
+++ b/internal/web/blog/controller/blog.go
@@ -4,6 +4,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"html"
 	"regexp"
 	"strings"
 	"time"
@@ -193,12 +194,18 @@ func (r *QueryResolver) BlogTwitterCard(ctx context.Context,
 		}
 	}
 
+	return r.blogTwitterCardFormat(title, imgURL, name), nil
+}
+
+func (r *QueryResolver) blogTwitterCardFormat(title, imgURL, name string) string {
 	return fmt.Sprintf(gutils.Dedent(`
 		<meta name="twitter:card" content="summary_large_image">
 		<meta name="twitter:title" content="%s">
 		<meta name="twitter:image" content="%s">
 		<meta name="twitter:site" content="https://blog.laisky.com/p/%s/">`),
-		title, imgURL, name), nil
+		html.EscapeString(title),
+		html.EscapeString(imgURL),
+		html.EscapeString(name))
 }
 
 func (r *QueryResolver) BlogComments(ctx context.Context,

--- a/internal/web/blog/controller/blog_security_test.go
+++ b/internal/web/blog/controller/blog_security_test.go
@@ -1,0 +1,26 @@
+package controller
+
+import (
+	"testing"
+	"strings"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBlogTwitterCardFormatSecurity(t *testing.T) {
+	r := &QueryResolver{}
+	title := `"><script>alert(1)</script>`
+	imgURL := `"><img src=x onerror=alert(1)>`
+	name := `foo"bar`
+
+	output := r.blogTwitterCardFormat(title, imgURL, name)
+
+	// After the fix, these should be correctly escaped
+	assert.False(t, strings.Contains(output, title), "Output should not contain raw title")
+	assert.False(t, strings.Contains(output, imgURL), "Output should not contain raw imgURL")
+	assert.False(t, strings.Contains(output, name), "Output should not contain raw name")
+
+	assert.True(t, strings.Contains(output, `content="&#34;&gt;&lt;script&gt;alert(1)&lt;/script&gt;"`), "Title should be escaped")
+	assert.True(t, strings.Contains(output, `content="&#34;&gt;&lt;img src=x onerror=alert(1)&gt;"`), "ImgURL should be escaped")
+	assert.True(t, strings.Contains(output, `/p/foo&#34;bar/"`), "Name should be escaped")
+}


### PR DESCRIPTION
The `BlogTwitterCard` resolver was building an HTML snippet using `fmt.Sprintf` with unsanitized data from the database and user input. This allowed an attacker to perform Cross-Site Scripting (XSS) or break out of HTML attributes by using malicious strings in a blog post's title, image URL, or name.

This PR fixes the issue by:
1. Importing the `html` package.
2. Refactoring the formatting logic into an unexported method `blogTwitterCardFormat` for better testability.
3. Using `html.EscapeString()` to sanitize all variables before they are injected into the HTML string.
4. Adding a comprehensive unit test in `internal/web/blog/controller/blog_security_test.go` to verify the fix.

Vulnerability: XSS
Severity: HIGH
Impact: Potential account takeover or malicious script execution if the returned HTML is rendered by a frontend.

---
*PR created automatically by Jules for task [16307195720645866178](https://jules.google.com/task/16307195720645866178) started by @Laisky*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a cross-site scripting (XSS) vulnerability affecting social media card generation. User-provided content is now properly sanitized before display.

* **Tests**
  * Added security tests to verify proper input sanitization.

* **Documentation**
  * Added security documentation regarding XSS vulnerability remediation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->