### PR TITLE
⚡ Bolt: scan RAG tokens without regexp splitting

### DIFF
--- a/internal/mcp/rag/chunker_test.go
+++ b/internal/mcp/rag/chunker_test.go
@@ -16,3 +16,10 @@ func TestParagraphChunkerSplit(t *testing.T) {
 		require.LessOrEqual(t, len(fragment.Text), 40, "fragment exceeds limit: %d", len(fragment.Text))
 	}
 }
+
+// TestParagraphChunkerSplitPreservesTokenBehavior verifies the token sequence exposed by the chunker remains stable.
+func TestParagraphChunkerSplitPreservesTokenBehavior(t *testing.T) {
+	fragments := (ParagraphChunker{}).Split("AKB AİB. Hello, HELLO world!! world", 500)
+	require.Len(t, fragments, 1)
+	require.Equal(t, []string{"akb", "aib", "hello", "world"}, fragments[0].Tokens)
+}

--- a/internal/mcp/rag/tokenizer.go
+++ b/internal/mcp/rag/tokenizer.go
@@ -1,28 +1,37 @@
 package rag
 
-import (
-	"regexp"
-	"strings"
-)
-
-var nonWord = regexp.MustCompile(`[^a-z0-9]+`)
+import "strings"
 
 // Tokenize splits the text into lowercase alphanumeric tokens suitable for approximate BM25 scoring.
 func Tokenize(text string) []string {
 	lowered := strings.ToLower(text)
-	cleaned := nonWord.Split(lowered, -1)
-	tokens := make([]string, 0, len(cleaned))
+	tokens := make([]string, 0)
 	seen := make(map[string]struct{})
-	for _, token := range cleaned {
-		token = strings.TrimSpace(token)
-		if token == "" {
+	tokenStart := -1
+
+	// Scan lowered bytes directly to preserve the ASCII [a-z0-9] contract while
+	// avoiding regexp.Split's intermediate slice of every token occurrence.
+	for i := 0; i <= len(lowered); i++ {
+		if i < len(lowered) && isTokenByte(lowered[i]) {
+			if tokenStart == -1 {
+				tokenStart = i
+			}
 			continue
 		}
-		if _, ok := seen[token]; ok {
+		if tokenStart == -1 {
 			continue
 		}
-		seen[token] = struct{}{}
-		tokens = append(tokens, token)
+
+		token := lowered[tokenStart:i]
+		if _, ok := seen[token]; !ok {
+			seen[token] = struct{}{}
+			tokens = append(tokens, token)
+		}
+		tokenStart = -1
 	}
 	return tokens
+}
+
+func isTokenByte(value byte) bool {
+	return (value >= 'a' && value <= 'z') || (value >= '0' && value <= '9')
 }

--- a/internal/mcp/rag/tokenizer_test.go
+++ b/internal/mcp/rag/tokenizer_test.go
@@ -1,13 +1,108 @@
 package rag
 
 import (
+	"math/rand"
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
+var referenceNonWord = regexp.MustCompile(`[^a-z0-9]+`)
+
+// benchmarkTokenSink retains benchmark results so the compiler cannot eliminate tokenization as dead code.
+var benchmarkTokenSink []string
+
+// TestTokenize verifies the lowercase, ASCII token, order, and deduplication contract.
 func TestTokenize(t *testing.T) {
-	tokens := Tokenize("Hello, HELLO world!! world")
-	require.Len(t, tokens, 2, "expected 2 unique tokens")
-	require.Equal(t, "hello", tokens[0], "unexpected token order")
+	tests := []struct {
+		name string
+		text string
+		want []string
+	}{
+		{name: "empty", text: "", want: []string{}},
+		{name: "deduplicate and preserve order", text: "Hello, HELLO world!! world", want: []string{"hello", "world"}},
+		{name: "numbers and boundaries", text: "v2/api V2 API-42", want: []string{"v2", "api", "42"}},
+		{name: "unicode delimiters", text: "Crème 東京 CAFÉ", want: []string{"cr", "me", "caf"}},
+		{name: "unicode lowercase maps to ASCII", text: "AKB AİB", want: []string{"akb", "aib"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tokens := Tokenize(tt.text)
+			require.NotNil(t, tokens)
+			require.Equal(t, tt.want, tokens)
+		})
+	}
+}
+
+// TestTokenizeMatchesPreviousImplementation verifies exact equivalence with the previous regexp implementation for arbitrary byte strings.
+func TestTokenizeMatchesPreviousImplementation(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 2_000; i++ {
+		input := make([]byte, rng.Intn(1_025))
+		n, err := rng.Read(input)
+		require.NoError(t, err)
+		require.Equal(t, len(input), n)
+
+		text := string(input)
+		require.Equal(t, tokenizeReference(text), Tokenize(text), "tokenization drift for case %d", i)
+	}
+}
+
+// BenchmarkTokenizeRegexpSplit measures the previous regexp-based tokenizer.
+func BenchmarkTokenizeRegexpSplit(b *testing.B) {
+	benchmarkTokenize(b, tokenizeReference)
+}
+
+// BenchmarkTokenizeDirectScan measures the direct byte-scanning tokenizer.
+func BenchmarkTokenizeDirectScan(b *testing.B) {
+	benchmarkTokenize(b, Tokenize)
+}
+
+func benchmarkTokenize(b *testing.B, tokenizer func(string) []string) {
+	benchmarks := []struct {
+		name string
+		text string
+	}{
+		{name: "search_query_128B", text: strings.Repeat("GraphQL memory search token 42. ", 4)},
+		{name: "rag_chunk_512B", text: repeatToLength("GraphQL memory indexing keeps stable lexical tokens for documents. ", 512)},
+	}
+
+	for _, benchmark := range benchmarks {
+		b.Run(benchmark.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(benchmark.text)))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchmarkTokenSink = tokenizer(benchmark.text)
+			}
+			b.StopTimer()
+			require.NotEmpty(b, benchmarkTokenSink)
+		})
+	}
+}
+
+func repeatToLength(pattern string, length int) string {
+	return strings.Repeat(pattern, (length+len(pattern)-1)/len(pattern))[:length]
+}
+
+func tokenizeReference(text string) []string {
+	lowered := strings.ToLower(text)
+	cleaned := referenceNonWord.Split(lowered, -1)
+	tokens := make([]string, 0, len(cleaned))
+	seen := make(map[string]struct{})
+	for _, token := range cleaned {
+		token = strings.TrimSpace(token)
+		if token == "" {
+			continue
+		}
+		if _, ok := seen[token]; ok {
+			continue
+		}
+		seen[token] = struct{}{}
+		tokens = append(tokens, token)
+	}
+	return tokens
 }


### PR DESCRIPTION
## 💡 What

- Replaced `regexp.Split` tokenization with a direct ASCII byte scan after `strings.ToLower`.
- Preserved the existing contract exactly: lowercase ASCII-alphanumeric tokens, first-seen order, duplicate removal, Unicode lowercasing before token boundaries, and a non-nil empty result.
- Added a frozen reference implementation, targeted Unicode and invalid-UTF-8 cases, 2,000 deterministic random-byte equivalence cases, a chunker behavior test, and same-binary A/B benchmarks.

## 🎯 Why

`rag.Tokenize` is called for every RAG chunk during indexing and again on query/search normalization paths. The previous implementation lowercased the input, used a regexp to build an intermediate split slice, trimmed every result, and then allocated again for deduplication. The direct scanner identifies the same boundaries in one pass and avoids the regexp split slice and most per-token allocations.

## 🧪 Correctness

Validated against commit `78d44cd0c78b04b7cb6ad2e1a7d3b76f9799d064` with Go 1.27.0:

- `go vet ./...`
- `govulncheck ./...` — no called vulnerabilities
- `./.scripts/check_pure_go.sh`
- `./.scripts/check_system_owner.sh`
- `go test -race ./internal/mcp/rag -count=1`
- `go test -race -coverprofile=coverage.txt -covermode=atomic ./...`
- `go test -bench ./...`
- 2,000 deterministic oracle comparisons against the frozen pre-change tokenizer
- Targeted cases for ordering, duplicates, delimiters, digits, Unicode-to-ASCII lowercasing, and invalid UTF-8
- End-to-end chunker behavior assertion proving externally observable token output remains unchanged

Repository-native **Linter** workflow passed: [run 32674891308](https://github.com/Laisky/laisky-blog-graphql/actions/runs/32674891308).

The independent Bolt validation workflow also passed every correctness, race, security, invariant, equivalence, and benchmark gate: [run 32677419570](https://github.com/Laisky/laisky-blog-graphql/actions/runs/32677419570).

The repository's native CodeQL workflow is disabled and still references the obsolete CodeQL Action v1, so GitHub did not schedule a native PR CodeQL run. An isolated supported CodeQL v4 workflow checked the exact PR head and passed initialization, Go autobuild, analysis, and status publication: [run 32678157049](https://github.com/Laisky/laisky-blog-graphql/actions/runs/32678157049).

`make lint` was executed on both `master` and this commit. Both encounter the same pre-existing `honnef.co/go/tools` analyzer panic under Go 1.27 with golangci-lint v2.12.2 (`unexpected expr: *ast.KeyValueExpr`). The normalized failure signatures and formatter diffs are identical, and no diagnostic references the changed production file. This PR does not hide or broaden itself to fix that unrelated toolchain issue; the repository-native Linter workflow is green.

## 📊 Benchmark

Command:

```bash
go test ./internal/mcp/rag \
  -run '^$' \
  -bench '^BenchmarkTokenize(RegexpSplit|DirectScan)$' \
  -benchmem \
  -benchtime=500ms \
  -count=6 \
  -cpu=1
```

Go 1.27.0, Linux/amd64, AMD EPYC 9V45. Values are medians of six samples from the same process and benchmark binary.

| Scenario | Regexp baseline | Direct scan | Runtime change | Allocated bytes | Allocations |
|---|---:|---:|---:|---:|---:|
| 128-byte search query | 4,159.5 ns/op | 578.7 ns/op | **86.09% lower / 7.19× faster** | 3,480 → 368 B/op | 31 → 5 allocs/op |
| 512-byte RAG chunk | 13,731.0 ns/op | 2,016.5 ns/op | **85.31% lower / 6.81× faster** | 10,112 → 1,464 B/op | 83 → 9 allocs/op |

The 512-byte case represents the repository's approximately 500-character default RAG chunk size; the 128-byte case represents a realistic search/query normalization input.

## 🔬 Measurement

The benchmark keeps both implementations in the same test binary, feeds them byte-identical inputs, pins execution to one CPU, runs each case for 500 ms, collects six samples, and compares medians. This avoids cross-build methodology drift and runner-to-runner comparisons. The acceptance gate required at least 5% lower runtime and fewer allocated bytes in both scenarios; the observed gains are substantially larger.

Reproduction and complete logs: [Bolt final validation run 32677419570](https://github.com/Laisky/laisky-blog-graphql/actions/runs/32677419570).

## ⚠️ Risk

Low. There is no public API, dependency, configuration, storage, ordering, or error-semantic change. `strings.ToLower` still runs before scanning, preserving Unicode characters that lowercase into ASCII tokens. The scanner intentionally mirrors the old regexp class `[a-z0-9]`; the oracle tests cover arbitrary bytes and invalid UTF-8. Rollback is a single focused commit.

The benchmark covers representative query and default-chunk workloads rather than every possible corpus distribution, so the measured percentage should not be extrapolated directly to whole-request latency dominated by databases or embedding calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved text tokenization efficiency while preserving existing token results and ordering.

* **Quality Improvements**
  * Expanded coverage for punctuation, numbers, duplicate words, Unicode input, and empty text.
  * Added compatibility checks and performance benchmarks to verify consistent behavior across varied inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->